### PR TITLE
tutorial_numpy_1_1, 1_2 e 1_3 adicionados

### DIFF
--- a/master/tutorial_numpy_1_1.ipynb
+++ b/master/tutorial_numpy_1_1.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": "true"
+   },
+   "source": [
+    "# Table of Contents\n",
+    " <p><div class=\"lev1 toc-item\"><a href=\"#Introdução-ao-NumPy-no-ambiente-Adessowiki\" data-toc-modified-id=\"Introdução-ao-NumPy-no-ambiente-Adessowiki-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Introdução ao NumPy no ambiente Adessowiki</a></div><div class=\"lev2 toc-item\"><a href=\"#O-tipo-ndarray\" data-toc-modified-id=\"O-tipo-ndarray-11\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>O tipo ndarray</a></div><div class=\"lev1 toc-item\"><a href=\"#Manipulação-de-arrays\" data-toc-modified-id=\"Manipulação-de-arrays-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Manipulação de arrays</a></div><div class=\"lev2 toc-item\"><a href=\"#Criando-arrays-inicializados\" data-toc-modified-id=\"Criando-arrays-inicializados-21\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>Criando arrays inicializados</a></div><div class=\"lev2 toc-item\"><a href=\"#Criando-arrays-com-valores-sequenciais\" data-toc-modified-id=\"Criando-arrays-com-valores-sequenciais-22\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Criando arrays com valores sequenciais</a></div><div class=\"lev2 toc-item\"><a href=\"#Documentação-Oficial-Numpy\" data-toc-modified-id=\"Documentação-Oficial-Numpy-23\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>Documentação Oficial Numpy</a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introdução ao NumPy no ambiente Adessowiki\n",
+    "\n",
+    "## O tipo ndarray\n",
+    "\n",
+    "O tipo ndarray, ou apenas array é um arranjo de itens homogêneos de dimensionalidade N, indexados por uma tupla de N inteiros. Existem 3 informações essenciais associadas ao ndarray: o tipo dos dados, suas dimensões e seus dados em si. A propriedade dtype permite saber o tipo de dados enquanto que shape é uma tupla que indica o tamanho de cada dimensão do arranjo. O acesso aos dados em si deve ser feito por indexação, por fatiamento ou pela variável em si.\n",
+    "\n",
+    "Existem várias maneiras de criar uma variável do tipo ndarray. Por exemplo, é possível criar uma a partir de uma lista (1D) ou lista de listas usando a função array. O tipo de matriz resultante é deduzida a partir do tipo de elementos nas sequências.\n",
+    "\n",
+    "Veja a seguir um vetor de inteiros com 5 elementos. Note que o vetor é uma linha com 5 colunas. Observe também que o shape é uma tupla de um único elemento (veja a vírgula que aparece por ser uma tupla)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dimensões: a.shape= (5,)\n",
+      "Tipo dos elementos: a.dtype= int64\n",
+      "Imprimindo o array completo:\n",
+      " a= [ 2  3  4 -1 -2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "a = np.array( [2,3,4,-1,-2] )\n",
+    "print ('Dimensões: a.shape=', a.shape)\n",
+    "print ('Tipo dos elementos: a.dtype=', a.dtype)\n",
+    "print ('Imprimindo o array completo:\\n a=',a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Veja a seguir uma matriz bidimensional de dados ponto flutuante de 2 linhas e 3 colunas. Observe que a tupla do shape aumenta para a esquerda, isto é, se eu tiver um vetor de 3 elementos, o seu shape é (3,) e se uma nova dimensão for adicionada, por exemplo 2 linhas e 3 colunas, o shape passa a ser (3,2). O que antes shape[0] no vetor unidimensional era colunas, já na matrix bidimension shape[0] passou a ser o número de linhas. Assim o último elemento da tupla do shape indica o número de colunas, a penúltima o número de linhas. Assim se quisermos sempre buscar o número de colunas, independentemente do número de dimensões, shape[-1] informa sempre o número de colunas, shape[-2], o número de linhas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Um array bidimensional, dimensões:(b.shape= (2, 3)\n",
+      "Tipo dos elementos: b.dtype float64\n",
+      "Número de colunas: 3\n",
+      "Número de linhas: 2\n",
+      "Elementos, b=\n",
+      " [[ 1.5  2.3  5.2]\n",
+      " [ 4.2  5.6  4.4]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "b = np.array( [ [1.5, 2.3, 5.2],\n",
+    "                [4.2, 5.6, 4.4] ] )\n",
+    "print ('Um array bidimensional, dimensões:(b.shape=', b.shape)\n",
+    "print ('Tipo dos elementos: b.dtype', b.dtype)\n",
+    "print ('Número de colunas:', b.shape[-1])\n",
+    "print ('Número de linhas:', b.shape[-2])\n",
+    "print ('Elementos, b=\\n', b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Manipulação de arrays\n",
+    "\n",
+    "## Criando arrays inicializados\n",
+    "\n",
+    "É possível criar arrays de zeros, uns ou valores não inicializados usando as funções zeros, ones ou empty. As dimensões do array são obrigatórias e é dado por uma tupla e o tipo dos elementos é opcional, sendo que o default é tipo float.\n",
+    "\n",
+    "O código a seguir cria 3 arrays. O primeiro possui 2 linhas e 4 colunas. O segundo tem 3 dimensões: 3 fatias (ou imagens) onde cada uma tem 2 linhas e 5 colunas. Por último, é criado uma matriz booleana (True e False) de valores não inicializados de 2 linhas e 3 colunas. A vantagem do empty é que ele é mais rápido que o zeros ou ones. No caso abaixo, os valores mostrados na matrix criada pelo empty são aleatórios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Array de 0s: \n",
+      " [[ 0.  0.  0.  0.]\n",
+      " [ 0.  0.  0.  0.]]\n",
+      "\n",
+      "\n",
+      "Array de 1s: \n",
+      " [[[1 1 1 1 1]\n",
+      "  [1 1 1 1 1]]\n",
+      "\n",
+      " [[1 1 1 1 1]\n",
+      "  [1 1 1 1 1]]\n",
+      "\n",
+      " [[1 1 1 1 1]\n",
+      "  [1 1 1 1 1]]]\n",
+      "Array não inicializado (vazio):\n",
+      " [[False False False]\n",
+      " [False False False]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "d = np.zeros( (2,4) )\n",
+    "print ('Array de 0s: \\n', d)\n",
+    "\n",
+    "d = np.ones( (3,2,5), dtype='int16' )\n",
+    "print ('\\n\\nArray de 1s: \\n', d)\n",
+    "\n",
+    "d = np.empty( (2,3), 'bool' )\n",
+    "print ('Array não inicializado (vazio):\\n', d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note que o Numpy permite arrays n-dimensionais. Em imagens em níveis de cinza iremos trabalhar com matrizes bidimensionais mas se a imagem for colorida, iremos representá-la em 3 canais, R, G e B, representados na estrutura com 3 dimensões. Se for um vídeo, isto é, uma sequência de imagens, teremos que adicionar mais uma dimensão. Se for uma tomografia, também podemos representar em 3 dimensões: largura, altura e profundidade.\n",
+    "\n",
+    "## Criando arrays com valores sequenciais\n",
+    "\n",
+    "As funções arange e linspace geram um vetor sequencial. Eles diferem apenas nos parâmetros. Enquanto o arange gera uma sequência a partir dos valores inicial (includente e opcional), final( excludente) e passo (opcional), linspace gera uma sequência com valores inicial e final e número de elementos. Note as diferenças nos exemplos a seguir:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "np.arange( 10) =  [0 1 2 3 4 5 6 7 8 9]\n",
+      "np.arange( 3, 8) =  [3 4 5 6 7]\n",
+      "np.arange( 0, 2, 0.5) =  [ 0.   0.5  1.   1.5]\n",
+      "np.linspace( 0, 2, 5 ) =  [ 0.   0.5  1.   1.5  2. ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('np.arange( 10) = ', np.arange(10))\n",
+    "print('np.arange( 3, 8) = ', np.arange(3,8))\n",
+    "print('np.arange( 0, 2, 0.5) = ', np.arange(0, 2, 0.5))\n",
+    "print('np.linspace( 0, 2, 5 ) = ', np.linspace( 0, 2, 5 ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Veja que no último caso, usando o linspace, a sequência começa em 0 e termina em 2 e deve possuir 5 elementos. Veja que para isto o passo a ser utilizado será 0.5, calculado automaticamente. Já no exemplo anterior, a sequência começa em 0 e deve terminar antes de 2 e o passo é 0.5.\n",
+    "\n",
+    "## Documentação Oficial Numpy\n",
+    "\n",
+    "[numpy array](https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "65px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": true,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/master/tutorial_numpy_1_2.ipynb
+++ b/master/tutorial_numpy_1_2.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": "true"
+   },
+   "source": [
+    "# Table of Contents\n",
+    " <p><div class=\"lev1 toc-item\"><a href=\"#Fatiamento-em-narray-unidimensional\" data-toc-modified-id=\"Fatiamento-em-narray-unidimensional-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Fatiamento em narray unidimensional</a></div><div class=\"lev1 toc-item\"><a href=\"#Inicializando-um-array-unidimensional\" data-toc-modified-id=\"Inicializando-um-array-unidimensional-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Inicializando um array unidimensional</a></div><div class=\"lev1 toc-item\"><a href=\"#Exemplo-simples-de-fatiamento\" data-toc-modified-id=\"Exemplo-simples-de-fatiamento-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Exemplo simples de fatiamento</a></div><div class=\"lev1 toc-item\"><a href=\"#Exemplo-de-fatiamento-com-indices-negativos\" data-toc-modified-id=\"Exemplo-de-fatiamento-com-indices-negativos-4\"><span class=\"toc-item-num\">4&nbsp;&nbsp;</span>Exemplo de fatiamento com indices negativos</a></div><div class=\"lev2 toc-item\"><a href=\"#Acessando-o-último-elemento-com-índice-negativo\" data-toc-modified-id=\"Acessando-o-último-elemento-com-índice-negativo-41\"><span class=\"toc-item-num\">4.1&nbsp;&nbsp;</span>Acessando o último elemento com índice negativo</a></div><div class=\"lev2 toc-item\"><a href=\"#Inversão-do-array-com-step-negativo-(step-=--1)\" data-toc-modified-id=\"Inversão-do-array-com-step-negativo-(step-=--1)-42\"><span class=\"toc-item-num\">4.2&nbsp;&nbsp;</span>Inversão do array com step negativo (step = -1)</a></div><div class=\"lev1 toc-item\"><a href=\"#Fatiamento-avançado\" data-toc-modified-id=\"Fatiamento-avançado-5\"><span class=\"toc-item-num\">5&nbsp;&nbsp;</span>Fatiamento avançado</a></div><div class=\"lev2 toc-item\"><a href=\"#Supressão-do-indice-limite-inferior\" data-toc-modified-id=\"Supressão-do-indice-limite-inferior-51\"><span class=\"toc-item-num\">5.1&nbsp;&nbsp;</span>Supressão do indice limite inferior</a></div><div class=\"lev2 toc-item\"><a href=\"#Supressão-do-indice-limite-superior\" data-toc-modified-id=\"Supressão-do-indice-limite-superior-52\"><span class=\"toc-item-num\">5.2&nbsp;&nbsp;</span>Supressão do indice limite superior</a></div><div class=\"lev2 toc-item\"><a href=\"#Supressão-do-indice-do-step\" data-toc-modified-id=\"Supressão-do-indice-do-step-53\"><span class=\"toc-item-num\">5.3&nbsp;&nbsp;</span>Supressão do indice do step</a></div><div class=\"lev2 toc-item\"><a href=\"#Todos-os-elementos-com-passo-unitário\" data-toc-modified-id=\"Todos-os-elementos-com-passo-unitário-54\"><span class=\"toc-item-num\">5.4&nbsp;&nbsp;</span>Todos os elementos com passo unitário</a></div><div class=\"lev1 toc-item\"><a href=\"#Documentação-Oficial-Numpy\" data-toc-modified-id=\"Documentação-Oficial-Numpy-6\"><span class=\"toc-item-num\">6&nbsp;&nbsp;</span>Documentação Oficial Numpy</a></div><div class=\"lev1 toc-item\"><a href=\"#Links-Interessantes\" data-toc-modified-id=\"Links-Interessantes-7\"><span class=\"toc-item-num\">7&nbsp;&nbsp;</span>Links Interessantes</a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fatiamento em narray unidimensional\n",
+    "\n",
+    "Um recurso importante do numpy é o fatiamento no qual é possível acessar um subconjunto do array de diversas formas. O fatiamento define os índices onde o array será acessado definindo o ponto inicial, final e o passo entre eles, nesta ordem: [inicial:final:passo]."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inicializando um array unidimensional"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a = \n",
+      " [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "a = np.arange(20) # a é um vetor de dimensão 20\n",
+    "print('a = \\n', a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exemplo simples de fatiamento\n",
+    "\n",
+    "Para a realização do fatiamento são utilizados 3 parâmetros, colocados no local do índice do array. Os 3 parâmetros são separados por dois pontos \":\". Todos os 3 parâmetros podem ser opcionais que ocorrem quando o valor inicial é 0, o valor final é o tamanho do array e o passo é 1. Lembrar que a ordem deles é: [inicial:final:passo]. Se o passo for 1 fica: [inicial:final]. Se o início for 0 fica: [:final] e se o final for o último fica: [inicio:] e se forem todos [:].\n",
+    "\n",
+    "O fatiamento é feito começando pelo primeiro valor, adicionando-se o passo até antes do último valor. Três aspectos são extremamente importantes de serem lembrados: O índice inicial começa em zero, o índice final nunca é atingido, o último índice utilizado é sempre o imediatamente anterior e o Numpy admite índices negativos, que é uma indexação do último (-1) até o primeiro elemento (-W).\n",
+    "\n",
+    "Os exemplos a seguir ajudam a fixar estes conceitos.\n",
+    "\n",
+    "O código abaixo acessa os elementos ímpares começando de 1 até 14:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[1:15:2]\n",
+      "[ 1  3  5  7  9 11 13]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[1:15:2]')\n",
+    "print(a[1:15:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exemplo de fatiamento com indices negativos\n",
+    "\n",
+    "## Acessando o último elemento com índice negativo\n",
+    "\n",
+    "O código abaixo acessa os elementos ímpares até antes do último elemento:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[1:-1:2]\n",
+      "[ 1  3  5  7  9 11 13 15 17]\n",
+      "Note que o fatiamento termina antes do último elemento (-1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[1:-1:2]')\n",
+    "print(a[1:-1:2])\n",
+    "print('Note que o fatiamento termina antes do último elemento (-1)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inversão do array com step negativo (step = -1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[-3:2:-1]\n",
+      "[17 16 15 14 13 12 11 10  9  8  7  6  5  4  3]\n",
+      "Note que o fatiamento retorna o array invertido\n",
+      "Antepenúltimo até o terceiro elemento com step = -1\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[-3:2:-1]')\n",
+    "print(a[-3:2:-1])\n",
+    "print('Note que o fatiamento retorna o array invertido')\n",
+    "print('Antepenúltimo até o terceiro elemento com step = -1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fatiamento avançado\n",
+    "\n",
+    "É possível realizar o fatiamento utilizando os 3 parâmetros explícitos ( o limite inferior, limite superior e o step), ou podemos suprimir algum desses parâmetros. Nestes casos a função toma o valor defaut: limite inferior = primeiro elemento, limite superior = último elemento e step = 1.\n",
+    "\n",
+    "É possível realizar o fatiamento utilizando os 3 parâmetros explícitos\n",
+    "( o limite inferior, limite superior e o step), ou podemos suprimir algum \n",
+    "desses parâmetros. Nestes casos a função toma o valor defaut: limite \n",
+    "inferior = primeiro elemento, limite superior = último elemento e step = 1.\n",
+    "\n",
+    "\n",
+    "|Proposta inicial     | Equivalente |\n",
+    "|---------------------|-------------|\n",
+    "|a[0:len(a):1]        | a[:]        |\n",
+    "|a[0:10:1]            | a[:10]      |\n",
+    "|a[0:10:2]            | a[:10:2]    |\n",
+    "|a[2:len(a):1]        | a[2::]      |\n",
+    "|a[2:len(a):2]        | a[2::2]     |\n",
+    "\n",
+    "\n",
+    "## Supressão do indice limite inferior\n",
+    "\n",
+    "Quando o índice do limite inferior é omitido, é subentendido que é 0:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[:15:2]\n",
+      "[ 0  2  4  6  8 10 12 14]\n",
+      "Note que o fatiamento inicia do primeiro elemento\n",
+      "Primeiro elemento até antes do 15o com passo duplo\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[:15:2]')\n",
+    "print(a[:15:2])\n",
+    "print('Note que o fatiamento inicia do primeiro elemento')\n",
+    "print('Primeiro elemento até antes do 15o com passo duplo')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supressão do indice limite superior\n",
+    "\n",
+    "Quando o índice do limite superior é omitido, fica implícito que é o último elemento:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[1::2]\n",
+      "[ 1  3  5  7  9 11 13 15 17 19]\n",
+      "Note que o fatiamento termina último elemento\n",
+      "Primeiro elemento até o último com passo duplo\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[1::2]')\n",
+    "print(a[1::2])\n",
+    "print('Note que o fatiamento termina último elemento')\n",
+    "print('Primeiro elemento até o último com passo duplo')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supressão do indice do step\n",
+    "\n",
+    "O índice do step é opcional e quando não é indicado, seu valor é 1:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[1:15]\n",
+      "[ 1  2  3  4  5  6  7  8  9 10 11 12 13 14]\n",
+      "Note que o fatiamento tem step unitário\n",
+      "Primeiro elemento até antes do 15o com passo um\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[1:15]')\n",
+    "print(a[1:15])\n",
+    "print('Note que o fatiamento tem step unitário')\n",
+    "print('Primeiro elemento até antes do 15o com passo um')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Todos os elementos com passo unitário"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultado da operação a[:]\n",
+      "[ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]\n",
+      "Todos os elementos com passo unitário\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(20)\n",
+    "print('Resultado da operação a[:]')\n",
+    "print(a[:])\n",
+    "print('Todos os elementos com passo unitário')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Documentação Oficial Numpy\n",
+    "\n",
+    "[Scipy.org: indexação](https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html)\n",
+    "\n",
+    "# Links Interessantes\n",
+    "\n",
+    "[Scipy Lectures: Indexação e fatiamento](http://www.scipy-lectures.org/intro/numpy/array_object.html#indexing-and-slicing)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "65px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": true,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/master/tutorial_numpy_1_3.ipynb
+++ b/master/tutorial_numpy_1_3.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": "true"
+   },
+   "source": [
+    "# Table of Contents\n",
+    " <p><div class=\"lev1 toc-item\"><a href=\"#Fatiamento-no-ndarray-bidimensional\" data-toc-modified-id=\"Fatiamento-no-ndarray-bidimensional-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Fatiamento no ndarray bidimensional</a></div><div class=\"lev2 toc-item\"><a href=\"#Inicializando-um-array-e-mudando-o-seu-shape\" data-toc-modified-id=\"Inicializando-um-array-e-mudando-o-seu-shape-11\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>Inicializando um array e mudando o seu shape</a></div><div class=\"lev2 toc-item\"><a href=\"#Fatiamento-de-linhas-e-colunas-de-um-array\" data-toc-modified-id=\"Fatiamento-de-linhas-e-colunas-de-um-array-12\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>Fatiamento de linhas e colunas de um array</a></div><div class=\"lev2 toc-item\"><a href=\"#Fatiamento-de-elementos-específicos-de-um-array\" data-toc-modified-id=\"Fatiamento-de-elementos-específicos-de-um-array-13\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>Fatiamento de elementos específicos de um array</a></div><div class=\"lev2 toc-item\"><a href=\"#Fatiamento-com-índices-invertidos\" data-toc-modified-id=\"Fatiamento-com-índices-invertidos-14\"><span class=\"toc-item-num\">1.4&nbsp;&nbsp;</span>Fatiamento com índices invertidos</a></div><div class=\"lev1 toc-item\"><a href=\"#Documentação-Oficial-Numpy\" data-toc-modified-id=\"Documentação-Oficial-Numpy-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Documentação Oficial Numpy</a></div><div class=\"lev1 toc-item\"><a href=\"#Links-Interessantes\" data-toc-modified-id=\"Links-Interessantes-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Links Interessantes</a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fatiamento no ndarray bidimensional\n",
+    "\n",
+    "Um recurso importante do numpy é o fatiamento no qual é possível acessar partes do array de diversas formas, como pode ser visto abaixo:\n",
+    "\n",
+    "## Inicializando um array e mudando o seu shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a = \n",
+      " [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]\n",
+      "a.reshape(4,5) = \n",
+      " [[ 0  1  2  3  4]\n",
+      " [ 5  6  7  8  9]\n",
+      " [10 11 12 13 14]\n",
+      " [15 16 17 18 19]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "a = np.arange(20) # a é um vetor unidimensional de 20 elementos\n",
+    "print('a = \\n', a)\n",
+    "\n",
+    "a = a.reshape(4,5) # a agora é um array 4x5 (4 linhas por 5 colunas)\n",
+    "print('a.reshape(4,5) = \\n', a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fatiamento de linhas e colunas de um array\n",
+    "\n",
+    "O operador : indica que todos os elementos naquela dimensão devem ser acessados."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A segunda linha do array: \n",
+      " [5 6 7 8 9]\n",
+      " A primeira coluna do array: \n",
+      " [ 0  5 10 15]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('A segunda linha do array: \\n', a[1,:])  # A segunda linha é o índice 1\n",
+    "\n",
+    "print(' A primeira coluna do array: \\n', a[:,0]) # A primeira coluna corresponde ao índice 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fatiamento de elementos específicos de um array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Acessando as linhas do array de 2 em 2 começando pelo índice 0: \n",
+      " [[ 0  1  2  3  4]\n",
+      " [10 11 12 13 14]]\n",
+      " Acessando as linhas e colunas do array de 2 em 2 começando pela linha 0 e coluna 1: \n",
+      " [[ 1  3]\n",
+      " [11 13]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Acessando as linhas do array de 2 em 2 começando pelo índice 0: \\n', a[0::2,:])\n",
+    "\n",
+    "print(' Acessando as linhas e colunas do array de 2 em 2 começando pela linha 0 e coluna 1: \\n', a[0::2,1::2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fatiamento com índices invertidos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Acesso as duas últimas linhas do array em ordem reversa:\n",
+      " [[15 16 17 18 19]\n",
+      " [10 11 12 13 14]]\n",
+      "Acesso elemento na última linha e coluna do array:\n",
+      " 19\n",
+      "Invertendo a ordem das linhas do array:\n",
+      " [[15 16 17 18 19]\n",
+      " [10 11 12 13 14]\n",
+      " [ 5  6  7  8  9]\n",
+      " [ 0  1  2  3  4]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Acesso as duas últimas linhas do array em ordem reversa:\\n\", a[-1:-3:-1,:])\n",
+    "print(\"Acesso elemento na última linha e coluna do array:\\n\", a[-1,-1])\n",
+    "print(\"Invertendo a ordem das linhas do array:\\n\", a[::-1,:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Documentação Oficial Numpy\n",
+    "\n",
+    "[Scipy.org Princípios básicos de indexação de arrays](https://docs.scipy.org/doc/numpy/user/basics.indexing.html)\n",
+    "\n",
+    "# Links Interessantes\n",
+    "\n",
+    "[Scipy-lectures: operações avançadas com fatiamento](http://scipy-lectures.github.io/intro/numpy/array_object.html#fancy-indexing)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "158px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": true,
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
No tutorial_numpy_1_3 não adicionei os links da seção "Exemplos com imagens no Adessowiki" pois me foi dito que estão abandonando o adessowiki. Sendo assim os links poderiam não funcionar posteriormente.
Talvez fosse interessante fazer esses links com os respectivos notebooks, assim que eles forem criados.